### PR TITLE
feat: add death transition in boss fight

### DIFF
--- a/Assets/Scenes/PurgeDomain.unity
+++ b/Assets/Scenes/PurgeDomain.unity
@@ -1542,7 +1542,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 430494125}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -4284,6 +4284,11 @@ PrefabInstance:
       propertyPath: health
       value: 
       objectReference: {fileID: 114230832185833882}
+    - target: {fileID: 6082575806313374961, guid: 7d60c822c3f1b408ea7a00ecdb5e047a,
+        type: 3}
+      propertyPath: maxHP
+      value: 200
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -4909,6 +4914,7 @@ MonoBehaviour:
   Console: {fileID: 672624292}
   FPStateManager: {fileID: 1082779269}
   Player: {fileID: 114230832185833879}
+  FS: {fileID: 2063754849}
 --- !u!114 &1082779269
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4953,6 +4959,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9473387ae50744bf946308793bd64e9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  FS: {fileID: 2063754849}
+  IsBossFight: 1
 --- !u!61 &1090666647
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -8060,6 +8068,104 @@ ParticleSystem:
     type: 3}
   m_PrefabInstance: {fileID: 1145736410}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2063754848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2063754851}
+  - component: {fileID: 2063754850}
+  - component: {fileID: 2063754849}
+  m_Layer: 0
+  m_Name: BlackoutScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2063754849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063754848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: caa2cb370e0fc8e45904d35214274158, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &2063754850
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063754848}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 9
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6,
+    type: 3}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2063754851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063754848}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.7558, y: 0.3573, z: 0}
+  m_LocalScale: {x: 40.18844, y: 14.2264, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &2084730434 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 6810471105834413002, guid: 97c43495f80a3244fad1301dfafbe252,

--- a/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
@@ -1,6 +1,7 @@
 using Platformer.Core;
 using Platformer.Mechanics;
 using Platformer.Model;
+using UnityEngine;
 using static Platformer.Core.Simulation;
 
 namespace Platformer.Gameplay
@@ -18,7 +19,7 @@ namespace Platformer.Gameplay
 
         public override void Execute()
         {
-            var willHurtEnemy = player.Bounds.center.y >= enemy.Bounds.max.y;
+            var willHurtEnemy = false;
 
             if (willHurtEnemy)
             {
@@ -51,7 +52,6 @@ namespace Platformer.Gameplay
                 else
                 {
                     player.audioSource.PlayOneShot(player.ouchAudio);
-                    player.Bounce(30);
                     player.health.maxHP--;
                 }
             }

--- a/Assets/Scripts/Gameplay/SceneRestart.cs
+++ b/Assets/Scripts/Gameplay/SceneRestart.cs
@@ -1,0 +1,13 @@
+using Platformer.Core;
+using UnityEngine.SceneManagement;
+
+namespace Platformer.Gameplay
+{
+    public class SceneRestart : Simulation.Event<SceneRestart>
+    {
+        public override void Execute()
+        {
+            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/SceneRestart.cs.meta
+++ b/Assets/Scripts/Gameplay/SceneRestart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d44efe09ac622ab49b9a36ceda2f57e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Hunter/Behaviour/CleaveController.cs
+++ b/Assets/Scripts/Hunter/Behaviour/CleaveController.cs
@@ -61,7 +61,9 @@ namespace Hunter.Behaviour
             var p = collider.gameObject.GetComponent<PlayerController>();
             if (p != null && TriggerDeathZone)
             {
-                Schedule<PlayerEnemyCollision>();
+                PlayerEnemyCollision ev = Schedule<PlayerEnemyCollision>();
+                ev.player = p;
+                ev.enemy = null;
             }
         }
         void OnTriggerStay2D(Collider2D collider)
@@ -69,7 +71,9 @@ namespace Hunter.Behaviour
             var p = collider.gameObject.GetComponent<PlayerController>();
             if (p != null && TriggerDeathZone)
             {
-                Schedule<PlayerEnemyCollision>();
+                PlayerEnemyCollision ev = Schedule<PlayerEnemyCollision>();
+                ev.player = p;
+                ev.enemy = null;
             }
         }
 

--- a/Assets/Scripts/Mechanics/DeathZone.cs
+++ b/Assets/Scripts/Mechanics/DeathZone.cs
@@ -10,13 +10,23 @@ namespace Platformer.Mechanics
     /// </summary>
     public class DeathZone : MonoBehaviour
     {
+        [SerializeField] FlushScreen FS;
+        [SerializeField] bool IsBossFight = false;
         void OnTriggerEnter2D(Collider2D collider)
         {
             var p = collider.gameObject.GetComponent<PlayerController>();
             if (p != null)
             {
-                var ev = Schedule<PlayerEnteredDeathZone>();
-                ev.deathzone = this;
+                if (IsBossFight && FS != null)
+                {
+                    Schedule<SceneRestart>(1.5f);
+                    FS.StartFlushing();
+                }
+                else
+                {
+                    var ev = Schedule<PlayerEnteredDeathZone>();
+                    ev.deathzone = this;
+                }
             }
         }
     }

--- a/Assets/Scripts/Mechanics/FightPlatformsController.cs
+++ b/Assets/Scripts/Mechanics/FightPlatformsController.cs
@@ -1,8 +1,9 @@
 using System.Collections;
 using Platformer.Mechanics.Fight.FloatingPlatformState;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using TMPro;
+using Platformer.Gameplay;
+using static Platformer.Core.Simulation;
 
 namespace Platformer.Mechanics
 {
@@ -20,6 +21,8 @@ namespace Platformer.Mechanics
         [SerializeField] public TextMeshPro Console;
         [SerializeField] public StateManager FPStateManager;
         [SerializeField] PlayerController Player;
+        [SerializeField] FlushScreen FS;
+        bool alive = true;
         void Start()
         {
             Invoke(nameof(CountDonwToMovePlatforms), time);
@@ -43,9 +46,11 @@ namespace Platformer.Mechanics
             {
                 LowerPlatform.transform.position = Vector3.MoveTowards(LowerPlatform.transform.position, LowerPlatformPath.endPosition, Time.deltaTime * 0.4f);
             }
-            if (Player.health.maxHP <= 0)
+            if (Player.health.maxHP <= 0 && alive)
             {
-                SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+                Schedule<SceneRestart>(1.5f);
+                FS.StartFlushing();
+                alive = false;
             }
         }
 

--- a/Assets/Scripts/Mechanics/FlushScreen.cs
+++ b/Assets/Scripts/Mechanics/FlushScreen.cs
@@ -21,7 +21,7 @@ namespace Platformer.Mechanics
 
         IEnumerator Flushing()
         {
-            for (float i = 0; i <= 1; i += 0.1f)
+            for (float i = 0; i < 1; i += 0.1f)
             {
                 Color newColor = spriteRenderer.color;
                 newColor.a = i;


### PR DESCRIPTION
closes #91 

Add a death transition for the boss when the player dies and restarts the scene, instead of just respawning.